### PR TITLE
Sprint2 registration andy

### DIFF
--- a/NUboard-services/src/main/java/com/neu/nuboard/exception/ErrorCode.java
+++ b/NUboard-services/src/main/java/com/neu/nuboard/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     RESOURCE_NOT_FOUND(1003, "Resource Not Found", HttpStatus.NOT_FOUND),
     DATABASE_ERROR(1004, "Database Operation Failed", HttpStatus.INTERNAL_SERVER_ERROR),
 
-
+    // User Errors (2xxx)
+    USER_NOT_FOUND(2001, "User not found", HttpStatus.NOT_FOUND),
 
     // Event Error 3xxx
     EVENT_NOT_FOUND(3001, "Event Not Found", HttpStatus.NOT_FOUND),
@@ -20,9 +21,19 @@ public enum ErrorCode {
     EVENT_INVALID_ADDRESS(3005, "Invalid Event Address", HttpStatus.BAD_REQUEST),
     EVENT_INVALID_CREATOR(3006, "Invalid Event Creator", HttpStatus.BAD_REQUEST),
     EVENT_INVALID_ORGANIZER(3007, "Invalid Event Organizer", HttpStatus.BAD_REQUEST),
-    EVENT_ALREADY_EXISTS(3008, "Event Already Exists", HttpStatus.CONFLICT),
-    EVENT_PARTICIPANT_ALREADY_REGISTERED(3009, "Participant Already Registered for Event", HttpStatus.CONFLICT),
-    EVENT_PARTICIPANT_INVALID(3010, "Invalid Participant", HttpStatus.BAD_REQUEST);
+
+
+    // Registration Errors (4xxx)
+    /**
+     * Indicates that the user is already registered for the event.
+     * HttpStatus 409 Conflict.
+     */
+    ALREADY_REGISTERED(4001, "User already registered", HttpStatus.CONFLICT),
+    /**
+     * Indicates that the registration record for the specified event and user was not found.
+     * HttpStatus 404 Not Found.
+     */
+    REGISTRATION_NOT_FOUND(4002, "Registration not found", HttpStatus.NOT_FOUND);
 
     private final int code;
     private final String message;

--- a/NUboard-services/src/main/java/com/neu/nuboard/model/OrganizerType.java
+++ b/NUboard-services/src/main/java/com/neu/nuboard/model/OrganizerType.java
@@ -1,0 +1,6 @@
+package com.neu.nuboard.model;
+
+public enum OrganizerType {
+    SCHOOL,
+    CORPORATE
+}

--- a/NUboard-services/src/main/java/com/neu/nuboard/repository/UserRepository.java
+++ b/NUboard-services/src/main/java/com/neu/nuboard/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.neu.nuboard.repository;
+
+import com.neu.nuboard.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository interface for User entity.
+ * Extends JpaRepository to provide CRUD operations for the users table.
+ */
+public interface UserRepository extends JpaRepository<User, String> {
+}

--- a/NUboard-services/src/main/java/com/neu/nuboard/service/EventRegistrationService.java
+++ b/NUboard-services/src/main/java/com/neu/nuboard/service/EventRegistrationService.java
@@ -51,10 +51,10 @@ public class EventRegistrationService {
     public void registerForEvent(String eventId, String userId) {
         // Validate input
         if (eventId == null || eventId.trim().isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
         if (userId == null || userId.trim().isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
 
         // Find the event and user
@@ -87,10 +87,10 @@ public class EventRegistrationService {
     public void unregisterForEvent(String eventId, String userId) {
         // Validate input
         if (eventId == null || eventId.trim().isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
         if (userId == null || userId.trim().isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
 
         // Find the registration
@@ -110,7 +110,7 @@ public class EventRegistrationService {
      */
     public List<EventRegistrationDTO> getRegistrationsByEventId(String eventId) {
         if (eventId == null || eventId.trim().isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
         return registrationRepository.findByEventId(eventId)
                 .stream()
@@ -127,7 +127,7 @@ public class EventRegistrationService {
      */
     public List<EventRegistrationDTO> getRegistrationsByUserId(String userId) {
         if (userId == null || userId.trim().isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
         return registrationRepository.findByUserId(userId)
                 .stream()
@@ -157,7 +157,7 @@ public class EventRegistrationService {
         return new EventRegistrationDTO(
                 registration.getId(),
                 registration.getEvent().getId(),
-                registration.getUser().getId()
+                registration.getUser().getId().toString()
         );
     }
 }


### PR DESCRIPTION
Fix registration part errors in ErrorCode and EventRegistrationService.

1. ErrorCode.java: Add Registration Errors (4xxx)
// Registration Errors (4xxx)
    /**
     * Indicates that the user is already registered for the event.
     * HttpStatus 409 Conflict.
     */
    ALREADY_REGISTERED(4001, "User already registered", HttpStatus.CONFLICT),
    /**
     * Indicates that the registration record for the specified event and user was not found.
     * HttpStatus 404 Not Found.
     */
    REGISTRATION_NOT_FOUND(4002, "Registration not found", HttpStatus.NOT_FOUND);

2. EventRegistrationService.java: Fix the getUser().getId() to string, because the userid in User entity is UUID object, but the userid I use in registration related files are string type. Therefore, I need to use .toString() for the consistency.
/**
     * Maps an {@link EventRegistration} entity to an {@link EventRegistrationDTO}.
     *
     * @param registration the EventRegistration entity to map
     * @return an {@link EventRegistrationDTO} containing the registration details
     */
    private EventRegistrationDTO mapToDTO(EventRegistration registration) {
        return new EventRegistrationDTO(
                registration.getId(),
                registration.getEvent().getId(),
                registration.getUser().getId().toString() // **Fix here!!! -> Add .toString()** 
        );
    }